### PR TITLE
Fix function `stall_randomly()`

### DIFF
--- a/scripts/worksim.py
+++ b/scripts/worksim.py
@@ -31,7 +31,7 @@ class WorkSimulator(object):
         """
         Wait for an interval that is randomly sampled from a lognormal distribution
         """
-        time.sleep(np.random.normal(mean, sigma, size=None))
+        time.sleep(np.random.lognormal(mean, sigma, size=None))  # Fixed with love, xoxo, UserLambda
 
     def fake_work(self):
         while True:


### PR DESCRIPTION
# PR description
- Fixes issue #1 
- changed call to function `np.random.normal()` into `np.random.lognormal()` in function `stall_randomly()`